### PR TITLE
疲労回復通知が 1分前に来るの修正

### DIFF
--- a/src/js/definitions/models/events/SoloEventBase.js
+++ b/src/js/definitions/models/events/SoloEventBase.js
@@ -11,7 +11,7 @@ var KanColleWidget = KanColleWidget || {};
 
         if(typeof this.finish != 'number') this.finish = (new Date(this.finish)).getTime();
 
-        if (this.kind.match(/createship/) == null) {
+        if (this.kind.match(/createship|sortie/) == null) {
             var notifyOffset = Config.get('notification-offset-millisec');
             this.finish = this.finish - notifyOffset;
         }

--- a/src/js/pages/view/dashboard/TirednessView.js
+++ b/src/js/pages/view/dashboard/TirednessView.js
@@ -45,6 +45,7 @@ var widgetPages = widgetPages || {};
         if (! finishEpoch) return res;
 
         var diffMinute = (finishEpoch - Date.now()) / (1000 * 60);
+        if (diffMinute < 0) return res;
         var wholeMinutes = this.config.get("tiredness-recovery-minutes");
         res.width = Math.floor((diffMinute * 100)/wholeMinutes) + '%';
         if (diffMinute > (wholeMinutes*2)/3) {
@@ -52,7 +53,7 @@ var widgetPages = widgetPages || {};
         } else if (diffMinute > (wholeMinutes*1)/3) {
             res.color = 'yellow';
         }
-        res.message = Math.floor(diffMinute) + '分';
+        res.message = Math.ceil(diffMinute) + '分';
         return res;
     };
     TirednessView.prototype._time2Text = function(finishEpoch){


### PR DESCRIPTION
E-4 でレア掘り120周やってたら，疲労回復通知が 1分前に来てることに（今さら）気付いたので，修正パッチ作りました．

建造と疲労回復だけ offset 引かないようにしてます．

でぴったりまで待つと，残り時間がまだあるのに「0分」って出るのも妙かなと思って，floor() でなく ceil() 表示にしてみました．