### PR TITLE
add "ask before window close" setting

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -289,6 +289,7 @@
     <script type="text/javascript" src="../js/pages/view/settings/DownloadDirectoryView.js"></script>
     <script type="text/javascript" src="../js/pages/view/settings/ModifyOriginalTabView.js"></script>
     <script type="text/javascript" src="../js/pages/view/settings/UseWhiteModeAsDefaultView.js"></script>
+    <script type="text/javascript" src="../js/pages/view/settings/AskBeforeWindowCloseView.js"></script>
     <script type="text/javascript" src="../js/pages/view/settings/AuthTwitterView.js"></script>
     <script type="text/javascript" src="../js/pages/view/settings/TweetHashtagView.js"></script>
     <script type="text/javascript" src="../js/pages/view/settings/SyncSaveTypeView.js"></script>

--- a/src/js/definitions/models/MyStorage.js
+++ b/src/js/definitions/models/MyStorage.js
@@ -161,7 +161,8 @@ MyStorage.prototype.tearDown = function(){
         'enable-twitter-remind-createship'   : false,// Obsolete!!
         'enable-twitter-remind-confirm'      : false,// Obsolete!!
         'event-flag'                         : 0,// エイプリルフールとかを管理するやつ
-        'sort-by-finishtime'                 : false
+        'sort-by-finishtime'                 : false,
+        'ask-before-window-close'            : false
     },
 
     /* public: dict */repair : function(){

--- a/src/js/pages/proxy2.js
+++ b/src/js/pages/proxy2.js
@@ -88,6 +88,16 @@ $(function() {
         onResize();
         $(window).resize(onResize);
 
+        // ウィンドウを閉じる前に確認が必要なら beforeunload を設定
+        chrome.runtime.sendMessage(null, {
+            purpose: 'getConfig',
+            configKey: 'ask-before-window-close'
+        }, function (doAsk) {
+            if (doAsk) {
+                $(window).on('beforeunload', function () {return window.document.title});
+            }
+        });
+
         Util.adjustSizeOfWindowsOSImmediately(window);
     };
 

--- a/src/js/pages/safe.js
+++ b/src/js/pages/safe.js
@@ -14,6 +14,16 @@ $(function(){
     // リサイズ
     chrome.runtime.sendMessage({purpose:'resizeWindowAtWhite'});
 
+    // ウィンドウを閉じる前に確認が必要なら beforeunload を設定
+    chrome.runtime.sendMessage(null, {
+        purpose: 'getConfig',
+        configKey: 'ask-before-window-close'
+    }, function (doAsk) {
+        if (doAsk) {
+            $(window).on('beforeunload', function () {return window.document.title});
+        }
+    });
+
     // キーバインド登録
     /* {{{ ここはmanifest.jsonでどうにかなるんだってさ
     $(document).on('keyup',function(e){

--- a/src/js/pages/settings.js
+++ b/src/js/pages/settings.js
@@ -51,6 +51,7 @@ $(function(){
         (new widgetPages.ModifyOriginalTabView()).render(),
         (new widgetPages.UseWhiteModeAsDefaultView()).render(),
         (new widgetPages.HideAdressbarInSafemodeView()).render(),
+        (new widgetPages.AskBeforeWindowCloseView()).render(),
         (new KCW.Pages.AllowThirdParty().render().$el)
     );
 

--- a/src/js/pages/view/settings/AskBeforeWindowCloseView.js
+++ b/src/js/pages/view/settings/AskBeforeWindowCloseView.js
@@ -1,0 +1,11 @@
+/* jshint indent: 4 */
+var widgetPages = widgetPages || {};
+(function() {
+    'use strict';
+    var AskBeforeWindowCloseView = widgetPages.AskBeforeWindowCloseView = function(){
+        this.inputName = 'ask-before-window-close';
+        this.title = "ウィンドウを閉じる前に確認する";
+        this.description = 'ウィンドウクローズやページ遷移の前に確認ダイアログを出します。変更したらウィンドウを開き直してください。';
+    };
+    Util.extend(AskBeforeWindowCloseView, widgetPages.SettingCheckboxView);
+})();


### PR DESCRIPTION
Apple Magic Mouse の誤爆によるページ遷移に悩む友人提督のために，艦これウィジェットにも「ページ閉じる前に確認」を実装してみました．

onBeforeUnload の中で async に config 取ってくると上手くいかんので，Flash ロードの辺りにコード追加して config 次第でハンドラ仕込むかどうか分けてます．
通常と white で同じコードが！ コピペばんざい！ もっと上手い方法ないんだろーか……