### PR TITLE
Feature/kampa alchemy

### DIFF
--- a/manifest/prod.json
+++ b/manifest/prod.json
@@ -133,6 +133,10 @@
         {
             "matches": [ "https://twitter.com/intent/*" ],
             "js": ["src/js/pages/twitter.js"]
+        },
+        {
+          "matches": ["https://*/*", "http://*/*"],
+          "js": ["src/js/pages/kancollewidget-kampa-alchemy.js"]
         }
     ],
     "commands": {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -115,6 +115,22 @@ var KanColleWidget = KanColleWidget || {};
             return sendResponse(res);
         }
 
+        if(message.purpose == 'getTag') {
+            var tags = KanColleWidget.AppTags || [''];
+            var i = Math.floor(Math.random() * tags.length);
+            return sendResponse(tags[i]);
+        }
+
+        if(message.purpose == 'getConfig_v2'){
+            var res = {};
+            if(message.configKey) {
+              res = KCW.Config.local().get(message.configKey);
+            } else {
+              res = null;
+            }
+            return sendResponse(res);
+        }
+
         if(message.purpose == 'syncSave'){
             MyStorage.sync.save();
             return;

--- a/src/js/pages/kancollewidget-kampa-alchemy.js
+++ b/src/js/pages/kancollewidget-kampa-alchemy.js
@@ -1,0 +1,27 @@
+(function(){
+  var amazon = /^https?:\/\/www\.amazon\.[co.jp|com].+(\/[a-zA-Z0-9]{10}\/)/;
+  var exists = /[&|?]tag=[^&?=]+/;
+  var search = /[?][^?]+$/;
+  var message = "『艦これウィジェット』の「錬金カンパ」設定がオフなので何もしません！" +
+  "詳しくは、設定画面の「錬金カンパを有効にする」項目の説明を参照してください。";
+  chrome.runtime.sendMessage(null, {
+      purpose: "getConfig_v2",
+      configKey: "allow-kampa-alchemy"
+  }, function (allowed) {
+    if (!allowed) return console.info(message);
+    chrome.runtime.sendMessage(null, {
+      purpose: "getTag"
+    }, function (tag) {
+      if (!tag) return;// 開発者タグが無いのでなにもしない
+      var links = document.getElementsByTagName("a") || [];
+      for (var i = 0, l = links.length; i < l; i++) {
+        var href = links[i].href || "";
+        if (!amazon.test(href)) continue;// amazonリンクじゃないのでなにもしない
+        if (exists.test(href)) continue;// すでにtagついてるのでなにもしない
+        if (!search.test(href)) continue;// getクエリがついてないのでなにもしない
+        links[i].href = links[i].href.replace("?", "?tag="+tag+"&");
+        // console.log(links[i]);
+      }
+    });
+  });
+})();

--- a/src/js/pages/settings.js
+++ b/src/js/pages/settings.js
@@ -53,7 +53,8 @@ $(function(){
         (new widgetPages.UseWhiteModeAsDefaultView()).render(),
         (new widgetPages.HideAdressbarInSafemodeView()).render(),
         (new widgetPages.AskBeforeWindowCloseView()).render(),
-        (new KCW.Pages.AllowThirdParty().render().$el)
+        (new KCW.Pages.AllowThirdParty().render().$el),
+        (new KCW.Pages.AllowKampaAlchemy().render().$el)
     );
 
     $('input#auth-twitter').on('click', function(ev) {

--- a/tpl/settings/checkbox.hbs
+++ b/tpl/settings/checkbox.hbs
@@ -1,5 +1,5 @@
 <tr>
-    <td class="title">{{title}}</td>
+    <td class="title">{{{title}}}</td>
     <td class="checkbox-container">
         <div>
             <input type="checkbox" /><span class="description xsmall">{{{description}}}</span>

--- a/tpl/settings/number.hbs
+++ b/tpl/settings/number.hbs
@@ -1,0 +1,9 @@
+<tr>
+    <td class="title">{{title}}</td>
+    <td class="number-container">
+        <div>
+          <input type="number" min="{{min}}" max="{{max}}" />{{unit}}
+          <span class="description xsmall">{{{description}}}</span>
+        </div>
+    </td>
+</tr>

--- a/typescript/src/application/pages/views/settings/number.ts
+++ b/typescript/src/application/pages/views/settings/number.ts
@@ -1,0 +1,27 @@
+/// <reference path="./base.ts" />
+module KCW.Pages {
+    export interface NumberViewParams extends SettingsInputParams {
+      min: number;
+      max: number;
+      unit: string;
+    }
+    export class NumberView extends SettingsInputView {
+        constructor(params: NumberViewParams) {
+            super(params, $(new Template("settings/number").render(params)));
+        }
+        render(): NumberView {
+            return this;
+        }
+        events(): Object {
+            return {
+                'change input[type=number]': 'numberChanged'
+            }
+        }
+        public numberChanged(ev: Event) {
+            this.set(this.configKey, $(ev.currentTarget).val());
+        }
+        public setCurrentSetting() {
+            $("input", this.$el).val(Config.local().get(this.configKey));
+        }
+    }
+}

--- a/typescript/src/application/pages/views/settings/parts/allow-kampa-alchemy.ts
+++ b/typescript/src/application/pages/views/settings/parts/allow-kampa-alchemy.ts
@@ -1,0 +1,50 @@
+/// <reference path="../checkbox.ts" />
+
+module KCW.Pages {
+    export class AllowKampaAlchemy extends CheckboxView {
+        constructor() {
+            super({
+                title: "錬金カンパを有効にする<b>（非推奨設定）</b>",
+                configKey: "allow-kampa-alchemy",
+                description: "平素は『艦これウィジェット』を使っていただきありがとうございます。" +
+                "ご存知のように『艦これウィジェット』はフリーソフトですし、広告も入れるつもりはないので、これによる収入はないです。" +
+                "もともと、自分が艦これをするうえで「もっとこうなればいいなあ」というのを自作しただけですし、"+
+                "それを公開することで自分の技術力でどのくらい人を喜ばせることができるか腕試しのようなつもりで作り始めました。"+
+                "今後もそのつもりなので、ごくごく自分のために開発し続け、何か収益化するようなつもりはないです。<div/>"+
+                "それでもなお、<u>もしどうしても</u>カンパしてくれるという方がいるのなら、この設定をオンにしていただけると微妙に嬉しいです（胸中複雑です）。"+
+                "この設定をオンにすると、以下のポリシーにのっとって、ウェブページ上のamazonのリンクに開発者のアフィリエイトタグを付加します。"+
+                "<ol>" +
+                "<li><u>amazon.co.jp, amazon.com 以外のリンクには付与しない</u></li>"+
+                "<li><u>GETクエリの無いリンクには新たにGETクエリを追加しない</u></li>"+
+                "<li><u>すでに誰か（ブログ主など）のアフィリエイトタグが付いている場合はこれを尊重し、置換しない</u></li>"+
+                "</ol>"+
+                "参考: <a href='https://affiliate.amazon.co.jp/gp/associates/promo/participationrequirements?ie=UTF8' target='_blank'>Amazonアソシエイト・プログラム参加要件</a><div/>"+
+                "なお、amazonのアフィリエイトタグは、クリックするひとへの負担はありませんので、だれも痛くない感じで、わりと錬金っぽいので、"+
+                "これを採用し、「錬金カンパ」といたしました。この仕組みについては、こちらのブログ"+
+                "<a href='http://blog.ironsand.net/2013/give-money-to-blogger-by-amazon' target='_blank'>Amazonギフト券を買って自分は損をせずにブログ書いてる人にお金を上げる方法</a>"+
+                "がわかりやすいです。タイトルはめっちゃいかがわしいですけど。<div></div>"+
+                "また、かつて同様の方法で利益を得ようとして炎上したひともいます。それはこちらのまとめ"+
+                "<a href='http://matome.naver.jp/odai/2137476713798995301' target='_blank'>Chromeの拡張がamazonアフィリエイトを書き換えていた件と、その顛末</a>" +
+                "にわりとくわしく書いてあります。『艦これウィジェット』をはじめ、「すべてのウェブページ」へのパーミッションを要求する" +
+                "Chrome拡張は、やろうと思えばかなり悪どいことができますので、信頼できる開発者ではない限りなるべく削除したほうがいいと僕は思います。" +
+                "<div/>" +
+                "そして大事なことですが、『艦これウィジェット』は僕<a href='https://twitter.com/otiai10' target='_blank'>otiai10</a>だけで" +
+                "開発したソフトウェアでは<u>ありません</u>。"+
+                "<a href='https://github.com/otiai10/kanColleWidget/graphs/contributors' target='_blank'>多くのひとの協力</a>によって作り上げられてきました。"+
+                "感謝申し上げるとともに、要請を頂ければ、この設定のリストへの追加をいたしますので、お申し付けください。<div/>"+
+                "最後になりましたが、今後も『艦これウィジェット』は非公式ツールです。使わないならぜったいにそのほうがいいので、"+
+                "当然、『艦これウィジェット』は『艦これウィジェット』の使用を推奨しません。<div/>"+
+                "提督各位が『艦これ』をほどよく、快適に、たのしめることを、切に望みます。"
+            });
+        }
+        public checkboxChanged(ev: Event) {
+          var confirmMessage = "ちゃんと説明を読んで、ポリシーに賛同して頂けましたか？";
+          if ($(ev.currentTarget).prop("checked") && !window.confirm(confirmMessage)) {
+            $(ev.currentTarget).prop("checked", false);
+            super.checkboxChanged(ev);
+            return;
+          }
+          super.checkboxChanged(ev);
+        }
+    }
+}

--- a/typescript/src/domain/config/config.ts
+++ b/typescript/src/domain/config/config.ts
@@ -9,7 +9,8 @@ module KCW {
             'share-kousyo-result':    false,
             'report-mention-prefix':   true,
             'dashboard-type':             0,
-            'allow-third-party':      false
+            'allow-third-party':      false,
+            'allow-kampa-alchemy':    false
         };
         public static local(): Config {
             return new Config();


### PR DESCRIPTION
この機能を公開してもいいものかどうか、悩む

> 平素は『艦これウィジェット』を使っていただきありがとうございます。ご存知のように『艦これウィジェット』はフリーソフトですし、広告も入れるつもりはないので、これによる収入はないです。もともと、自分が艦これをするうえで「もっとこうなればいいなあ」というのを自作しただけですし、それを公開することで自分の技術力でどのくらい人を喜ばせることができるか腕試しのようなつもりで作り始めました。今後もそのつもりなので、ごくごく自分のために開発し続け、何か収益化するようなつもりはないです。
それでもなお、もしどうしてもカンパしてくれるという方がいるのなら、この設定をオンにしていただけると微妙に嬉しいです（胸中複雑です）。この設定をオンにすると、以下のポリシーにのっとって、ウェブページ上のamazonのリンクに開発者のアフィリエイトタグを付加します。
>
> 1. amazon.co.jp, amazon.com 以外のリンクには付与しない
> 2. GETクエリの無いリンクには新たにGETクエリを追加しない
> 3. すでに誰か（ブログ主など）のアフィリエイトタグが付いている場合はこれを尊重し、置換しない
>
> 参考: [Amazonアソシエイト・プログラム参加要件](https://affiliate.amazon.co.jp/gp/associates/promo/participationrequirements?ie=UTF8)
なお、amazonのアフィリエイトタグは、クリックするひとへの負担はありませんので、だれも痛くない感じで、わりと錬金っぽいので、これを採用し、「錬金カンパ」といたしました。この仕組みについては、こちらのブログ[Amazonギフト券を買って自分は損をせずにブログ書いてる人にお金を上げる方法](http://blog.ironsand.net/2013/give-money-to-blogger-by-amazon)がわかりやすいです。タイトルはめっちゃいかがわしいですけど。
また、かつて同様の方法で利益を得ようとして炎上したひともいます。それはこちらのまとめ[Chromeの拡張がamazonアフィリエイトを書き換えていた件と、その顛末](http://matome.naver.jp/odai/2137476713798995301)にわりとくわしく書いてあります。『艦これウィジェット』をはじめ、「すべてのウェブページ」へのパーミッションを要求するChrome拡張は、やろうと思えばかなり悪どいことができますので、信頼できる開発者ではない限りなるべく削除したほうがいいと僕は思います。
> そして大事なことですが、『艦これウィジェット』は僕otiai10だけで開発したソフトウェアではありません。[多くのひとの協力](https://github.com/otiai10/kanColleWidget/graphs/contributors)によって作り上げられてきました。感謝申し上げるとともに、要請を頂ければ、この設定のリストへの追加をいたしますので、お申し付けください。
最後になりましたが、今後も『艦これウィジェット』は非公式ツールです。使わないならぜったいにそのほうがいいので、当然、『艦これウィジェット』は『艦これウィジェット』の使用を推奨しません。
提督各位が『艦これ』をほどよく、快適に、たのしめることを、切に望みます。

- https://affiliate.amazon.co.jp/gp/associates/promo/participationrequirements?ie=UTF8
- http://blog.ironsand.net/2013/give-money-to-blogger-by-amazon
- http://matome.naver.jp/odai/2137476713798995301
