### PR TITLE
fix Chrome 47 notification issue

### DIFF
--- a/src/js/Notifier.js
+++ b/src/js/Notifier.js
@@ -163,7 +163,8 @@ var KanColleWidget = KanColleWidget || {};
             this.showParameters.title,
             {
                 body: this.showParameters.body,
-                icon: this.showParameters.icon
+                icon: this.showParameters.icon,
+                requireInteraction: true
             }
         );
         if (this.showParameters.stay === false) {
@@ -174,7 +175,11 @@ var KanColleWidget = KanColleWidget || {};
         if (this.showParameters.sound) {
             this.playSound();
         }
-        notification.onclick = this.showParameters.onClicked;
+        var onClicked = this.showParameters.onClicked;
+        notification.onclick = function () {
+            onClicked();
+            notification.close();
+        }
         this.showParameters.onCompleted();
     };
 })();


### PR DESCRIPTION
Chrome 47 で，デフォルトで通知が勝手に消えるようになったので，「勝手に消さない」フラグを付けました．
で，自動的に消えるモードの時はどうしようかと思ったけどこれまで通り「勝手に消さないモードの通知を自前 setTimeout で消す）のままにしてます．

あと通知の×ボタン以外をクリックしても消えてくれないので（これはうちの環境だけか？），クリック時に自前で即座に close() するようにしてます．