### PR TITLE
postinstallをWindows用に差し替え...(ると他環境で動かない)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "7.0.0"
   },
   "scripts": {
-    "postinstall": " if test -f app-config.json ; then echo \"\\033[0;32m[艦これウィジェット]\\033[m app-config.json already exists.\" ; else echo {} > app-config.json && echo \"\\033[0;32m[艦これウィジェット] app-config.json is generated.\\033[m\" ; fi ",
+    "postinstall": "if exist app-config.json (echo [艦これウィジェット] app-config.json already exists.) else (echo {} > app-config.json && echo [艦これウィジェット] app-config.json is generated.)",
     "test": "jest",
     "build": "webpack --progress",
     "release": "rm -rf release && mkdir -p release/kcwidget && node ./scripts/pre-release &&NODE_ENV=production webpack && cp -r dest release/kcwidget && cp manifest.json release/kcwidget && cp chrome_ex_oauth.html release/kcwidget && zip -r release/kcwidget.zip release/kcwidget/*",


### PR DESCRIPTION
windowsではBoot時にansi.sysを組み込まないとターミナル上でのエスケープシーケンス使用不可です。よって文字色変更が無理そう？
ひとまずエラーの原因は"test -f"、Windowsにおいてはこれは"exist"で代用します。
条件実行文はまとめてカッコつけといたほうが無難かも。
あとif-then-else-fiではなくif-else文なので"then"、"fi"は削除しました。
いかがでしょうか？初プルリクなので...

Windows 10(10.0.14393) 64-bit / nvmw / node 7.0.0 
"npm start"まで 動作確認しました。

以下動作確認時のログです、不要でしたら読み飛ばしてください。
初回実行がこちら
```C:\Users\Hourglass\Desktop\workspace\kanColleWidget>npm install
npm WARN deprecated babel@6.5.2: Babel's CLI commands have been moved from the babel package to the babel-cli package
npm WARN deprecated css-list@0.1.3: Deprecated.
npm WARN prefer global cover@0.2.9 should be installed with -g

> kcwidget@0.0.1 postinstall C:\Users\Hourglass\Desktop\workspace\kanColleWidget
> if exist app-config.json (echo [艦これウィジェット] app-config.json already exists.) else (echo {} > app-config.json && echo [艦これウィジェット] app-config.json is generated.)

[艦これウィジェット] app-config.json is generated.
kcwidget@0.0.1 C:\Users\Hourglass\Desktop\workspace\kanColleWidget
+-- babel@6.5.2
+-- babel-core@6.18.2
| +-- babel-code-frame@6.16.0

---------中略----------

  |     `-- set-immediate-shim@1.0.1
  `-- webpack-core@0.6.8
    `-- source-map@0.4.4
      `-- amdefine@1.0.1

npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^1.0.0 (node_modules\chokidar\node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.0.15: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})
```

二回目以降の処理はこうなりました。

```C:\Users\Hourglass\Desktop\workspace\kanColleWidget>npm install

> kcwidget@0.0.1 postinstall C:\Users\Hourglass\Desktop\workspace\kanColleWidget
> if exist app-config.json (echo [艦これウィジェット] app-config.json already exists.) else (echo {} > app-config.json && echo [艦これウィジェット] app-config.json is generated.)

[艦これウィジェット] app-config.json already exists.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^1.0.0 (node_modules\chokidar\node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.0.15: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})
```
