### PR TITLE
ダッシュボード：任務実績週リセットのテストケース追加

### DIFF
--- a/src/js/Components/Services/KanColleDate/index.js
+++ b/src/js/Components/Services/KanColleDate/index.js
@@ -52,11 +52,33 @@ export default class KanColleDate {
         const last = new this.constructor(lastTouched);
         // 7日以上の差がある場合は、問答無用で更新が必要
         if (this.jst.getTime() - last.jst.getTime() > 7*D) return true;
-        // 最終更新の曜日より、現時刻の曜日が先に進んでいる場合は更新が必要無い
-        if (last.getKcDay() < this.getKcDay()) return false;
-        // 同じ日ってことなので、5時をまたいでいたら更新が必要
-        if (last.jst.isBefore5AM() !== this.jst.isBefore5AM()) return true;
-        // 同じ日で5時をまたいでいないので更新の必要は無い
+
+        // 最終更新が月曜日でない場合
+        if (last.getKcDay() > 0) {
+            // 現時刻が月曜5時以降なら更新が必要
+            if (this.getKcDay() == 0 && !this.jst.isBefore5AM()) return true;
+            // 現時刻が月曜より先の日付なら更新が必要
+            if ((last.jst.getDate() != this.jst.getDate()) && (this.getKcDay() <= last.getKcDay())) return true;
+        }
+
+        // 最終更新が月曜日の場合
+        else {
+
+            // 最終更新時刻が5時前の場合
+            if (last.jst.isBefore5AM()) {
+                // 現時刻が月曜の5時以降なら更新が必要
+                if (this.getKcDay() == 0 && !this.jst.isBefore5AM()) return true;
+                // 現時刻が火曜以降なら更新が必要
+                if (this.getKcDay() > 0) return true;
+            }
+
+            // 最終更新時刻が5時以降の場合
+            else {
+                // 現時刻が最終更新と日付違いの月曜かつ5時以降なら更新が必要
+                if ((this.getKcDay() == 0 && !this.jst.isBefore5AM()) && (last.jst.getDate() != this.jst.getDate())) return true;
+            }
+        }
+
         return false;
     }
 }

--- a/tests/Components/Services/KanColleDate-test.js
+++ b/tests/Components/Services/KanColleDate-test.js
@@ -42,5 +42,11 @@ describe("KanColleDate", () => {
             const lastTouched = (new Date("Tue, 07 Feb 2017 10:00:00 CET")).getTime();
             expect(d.needsUpdateForWeekly(lastTouched)).toBe(false);
         });
+        it("前：先週の月曜7時、今：月曜6時というケースで正しくアップデートされる", () => {
+            const x = new Date("Mon Feb 06 2017 06:00:00 GMT+09:00");
+            const d = new KanColleDate(x);
+            const lastTouched = (new Date("Mon Jan 30 2017 07:00:00 GMT+09:00")).getTime();
+            expect(d.needsupdateForWeekly(lastTouched)).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
やったと思うこと
・needsUpdateForWeekly()に以下のテストを追加

最終更新と現在とが共に月曜だが最終は現在の7日前、共に5時を過ぎている場合に、実績がちゃんとリセットされる（時刻は最終＞現在なので総時間差は7dayに収まる）