### PR TITLE
大破進撃防止窓や通知をクリックしたときゲーム画面サイズが回復してしまうバグを修正

### DIFF
--- a/src/js/Components/Controllers/MessageControllers/Window.js
+++ b/src/js/Components/Controllers/MessageControllers/Window.js
@@ -15,7 +15,14 @@ const captures = new CaptureService();
 
 import OCR from "../../Services/API/OCR";
 
-export function OpenWindow(message) {
+/**
+ * 1. ゲーム画面がすでにあればそれをまずフォーカスする
+ *     a. メッセージによりフレームを指定されていればそのサイズに回復させる（誤操作からの回復）
+ *     b. フレームを指定されていない場合は、リサイズをせずフォーカスだけする
+ * 2. ゲーム画面が存在しなければ、指定されたフレームあるいは最後に指定したフレームで画面を作る
+ *     a. その際、最後に指定したミュート状態を引き継ぐ
+ */
+export function OpenWindow(message = {}) {
 
   let lastSelectedFrame = History.find("last-selected-frame");
   const id = message.frame || lastSelectedFrame.id;
@@ -33,7 +40,7 @@ export function OpenWindow(message) {
 
   return windows.find(true)
     .then(tab => windows.focus(tab))
-    .then(win => windows.resize(win, frame.size, position.architrave))
+    .then(win => message.frame ? windows.resize(win, frame.size, position.architrave) : Promise.resolve(win))
     .catch(() => windows.open(frame, position))
     .then(win => windows.mute(win.tabs[0], History.find("last-muted-status").muted));
 }

--- a/src/js/Components/Controllers/NotificationClickControllers/index.js
+++ b/src/js/Components/Controllers/NotificationClickControllers/index.js
@@ -20,7 +20,7 @@ function OnNotificationClicked(id) {
 
   return windows.find(true)
     .then(tab => windows.focus(tab))
-    .then(win => windows.resize(win, frame.size, position.architrave))
+    // .then(win => windows.resize(win, frame.size, position.architrave))
     .catch(() => windows.open(frame, position))
     .then(win => windows.mute(win.tabs[0], History.find("last-muted-status").muted));
 }


### PR DESCRIPTION
# 前提

- 大破進撃防止を別窓設定しているとき
- なおかつ、APPモードでゲームを表示しており、初期のサイズから自分で窓をひっぱってリサイズしているとき

# 問題

- 別窓表示された大破進撃防止窓をクリックすると、ゲーム画面が *最初にLAUNCHしたサイズ* に回復してしまう

# 原因

- 右上が使う `/window/open` というコントローラを使いまわしていたことによる

# 解決

- 右上からのリクエストは必ずframeパラメータがあることを加味し、
- コントローラにおいてframeパラメータが無い場合はresize（回復）を行わないようにした

# 備考

- 通知クリック時も同様にresize（回復）を行わないようにした