### PR TITLE
許可済み外部Chrome拡張チェック追加

### DIFF
--- a/src/js/Components/Controllers/ExternalMessageControllers/index.js
+++ b/src/js/Components/Controllers/ExternalMessageControllers/index.js
@@ -5,6 +5,12 @@ export function SubscribeStart() {
     _id:   this.sender.id, // 一応Chrome拡張につき一意に制限する
     extID: this.sender.id,
   });
+  const allow_list = Subscriber.list();
+  for (var i = 0; i < allow_list.length; i++) {
+      if (allow_list[i]._id == sub._id) {
+          return {status:304,message:"Your application is already subscribed."};
+      }
+  }
   if (!window.confirm(`Extension ID "${sub._id}" が『艦これウィジェット』との連携を要求しています。許可しますか？`)) {
     return {status:403,message:"ユーザが連携を拒否しました"};
   }

--- a/src/js/Components/Controllers/ExternalMessageControllers/index.js
+++ b/src/js/Components/Controllers/ExternalMessageControllers/index.js
@@ -8,7 +8,7 @@ export function SubscribeStart() {
   const allow_list = Subscriber.list();
   for (var i = 0; i < allow_list.length; i++) {
     if (allow_list[i]._id == sub._id) {
-      return {status:304,message:"Your application is already subscribed."};
+      return {status:304, message:"Your application is already subscribed."};
     }
   }
   if (!window.confirm(`Extension ID "${sub._id}" が『艦これウィジェット』との連携を要求しています。許可しますか？`)) {

--- a/src/js/Components/Controllers/ExternalMessageControllers/index.js
+++ b/src/js/Components/Controllers/ExternalMessageControllers/index.js
@@ -8,7 +8,7 @@ export function SubscribeStart() {
   const allow_list = Subscriber.list();
   for (var i = 0; i < allow_list.length; i++) {
     if (allow_list[i]._id == sub._id) {
-        return {status:304,message:"Your application is already subscribed."};
+      return {status:304,message:"Your application is already subscribed."};
     }
   }
   if (!window.confirm(`Extension ID "${sub._id}" が『艦これウィジェット』との連携を要求しています。許可しますか？`)) {

--- a/src/js/Components/Controllers/ExternalMessageControllers/index.js
+++ b/src/js/Components/Controllers/ExternalMessageControllers/index.js
@@ -7,9 +7,9 @@ export function SubscribeStart() {
   });
   const allow_list = Subscriber.list();
   for (var i = 0; i < allow_list.length; i++) {
-      if (allow_list[i]._id == sub._id) {
-          return {status:304,message:"Your application is already subscribed."};
-      }
+    if (allow_list[i]._id == sub._id) {
+        return {status:304,message:"Your application is already subscribed."};
+    }
   }
   if (!window.confirm(`Extension ID "${sub._id}" が『艦これウィジェット』との連携を要求しています。許可しますか？`)) {
     return {status:403,message:"ユーザが連携を拒否しました"};


### PR DESCRIPTION
外部Chrome拡張と連携済みであるIDの場合は確認ダイアログを表示せずに304(連携済み)を返却
※304はv1準拠

使用想定：通常の場合はダイアログを出さずにチェック終了させ、v1→v2になった等で連携が切れた場合などには確認ダイアログを再度表示するため。