### PR TITLE
第2期のHTMLで大破進撃防止窓の窓内表示が可能となるよう修正

### DIFF
--- a/src/js/Application/Routine/DamageSnapshot.js
+++ b/src/js/Application/Routine/DamageSnapshot.js
@@ -10,7 +10,7 @@ export default class DamageSnapshotDisplay {
     this.appendImage = this.appendImage.bind(this);
   }
   embed() {
-    return this.context.document.querySelector("embed");
+    return this.context.document.querySelector("div#flashWrap");
   }
   getContainer() {
     let container = this.context.document.querySelector(`div#${this.id}`);
@@ -60,14 +60,14 @@ export default class DamageSnapshotDisplay {
   }
   prepare() {
     console.log("DamageSnapshot", "prepare");
-    let embed = this.context.document.querySelector("embed");
+    let embed = this.embed();
     embed.setAttribute("wmode", "transparent");
     if (typeof embed.onmousedown == "function") return true;
     embed.addEventListener("mousedown", this.onmousedown);
     return true;
   }
   cleanup() {
-    let embed = this.context.document.querySelector("embed");
+    let embed = this.embed();
     embed.removeAttribute("wmode");
     embed.removeEventListener("mousedown", this.onmousedown, false);
     this.count = 0;


### PR DESCRIPTION
大破進撃防止窓の窓内表示時に表示箇所を見つけるためのセレクタをひとまず動くよう修正しました．
厳密には `div#flashWrap` の直下の `iframe` が1期の `embed` と等価な気がしますが，一応これで動いているようです．

DecoratePages の `embed#maintenanceswf` と `embed#externalswf` は触っていません．
前者はメンテナンス時でしょうかね，後者はAPPモード用？