### PR TITLE
Queue._scan() 引数の型を些細に修正

### DIFF
--- a/src/js/Applications/Models/Queue/Queue.ts
+++ b/src/js/Applications/Models/Queue/Queue.ts
@@ -7,7 +7,7 @@ export interface Scanned<T> {
 
 export default class Queue extends Model {
 
-  protected static _scan<T extends Queue>(constructor: any, now: number, clean: boolean = true): Scanned<T> {
+  protected static _scan<T extends Queue>(constructor: typeof Queue, now: number, clean: boolean = true): Scanned<T> {
     const s = { finished: [], upcomming: [] };
     constructor.list().map((q: Queue) => {
       if (q.scheduled < now) {


### PR DESCRIPTION
WebStorm で list() が補完効かないのなんでかなって思って……ｗ