### PR TITLE
getMonth()が0始まりなので+1する

### DIFF
--- a/src/js/Applications/Components/Dashboard/ClockView/index.tsx
+++ b/src/js/Applications/Components/Dashboard/ClockView/index.tsx
@@ -28,7 +28,7 @@ export default class ClockView extends React.Component<{
         <div className="clock-wrapper cell">
           <div className="date-wrapper">
             <div className="month">
-              <span>{now.getMonth()}</span>
+              <span>{now.getMonth() + 1}</span>
               <span>月</span>
             </div>
             <div className="date">


### PR DESCRIPTION
ダッシュボードの時計の日付の月部分がひと月前になっている(6月なら5月)ので+1した

FYI: [Date.prototype.getMonth() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth