### PR TITLE
途中で遠征を中止した場合、queueを消す

### DIFF
--- a/src/js/Applications/Background/Controllers/Request/Mission.ts
+++ b/src/js/Applications/Background/Controllers/Request/Mission.ts
@@ -1,6 +1,8 @@
 import NotificationService from "../../../../Services/Notification";
 import Mission from "../../../Models/Queue/Mission";
 import NotificationSetting from "../../../Models/Settings/NotificationSetting";
+import { DebuggableRequest } from "../../../../definitions/debuggable";
+import Recovery from "../../../Models/Queue/Recovery";
 
 export async function OnMissionStart(req: chrome.webRequest.WebRequestBodyDetails) {
   const { formData: { api_mission_id: [mid], api_deck_id: [did] } } = req.requestBody;
@@ -18,6 +20,15 @@ export async function OnMissionStart(req: chrome.webRequest.WebRequestBodyDetail
   await notifications.create(nid, setting.getChromeOptions(mission, false));
 
   return { status: 202, mission };
+}
+
+/**
+ * @MESSAGE /api_req_mission/return_instruction
+ * 遠征途中で中断帰投させたときの処理
+ */
+export async function OnMissionInterruption(req: DebuggableRequest) {
+  const { formData: { api_deck_id: [did]} } = req.requestBody;
+  return Mission.filter<Mission>(r => r.deck == did).map(r => r.delete());
 }
 
 export async function OnMissionResult(req: chrome.webRequest.WebRequestBodyDetails) {

--- a/src/js/Applications/Background/Routers/WebRequest.ts
+++ b/src/js/Applications/Background/Routers/WebRequest.ts
@@ -7,7 +7,7 @@ import {SerialRouter} from "chomex";
 
 import { OnAirBattleStarted, OnBattleStarted } from "../Controllers/Request/Battle";
 import { OnMapStart } from "../Controllers/Request/Map";
-import { OnMissionStart, OnMissionResult } from "../Controllers/Request/Mission";
+import { OnMissionStart, OnMissionInterruption, OnMissionResult } from "../Controllers/Request/Mission";
 import { OnPort } from "../Controllers/Request/Port";
 import { OnRecoveryStart, OnRecoveryHighspeed } from "../Controllers/Request/Recovery";
 import { OnShipbuildingStart, OnShipbuildingGetShip } from "../Controllers/Request/Shipbuilding";
@@ -33,6 +33,7 @@ router.on(["api_req_kousyou/getship"], OnShipbuildingGetShip);
 // 遠征関係
 router.on(["api_req_mission/start"], OnMissionStart);
 router.on(["api_req_mission/result"], OnMissionResult);
+router.on(["api_req_mission/return_instruction"], OnMissionInterruption);
 
 // 出撃
 router.on(["api_req_map/start"], OnMapStart); // 出撃開始


### PR DESCRIPTION
遠征中止したデータがダッシュボードに残っていたので消すようにした

FYI: https://github.com/otiai10/kanColleWidget/issues/1069