### PR TITLE
疲労回復タイマーのバーが 0～14 表示だったのを 1～15 表示になるよう変更

### DIFF
--- a/src/js/Applications/Components/Dashboard/QueuesView/TirednessView.tsx
+++ b/src/js/Applications/Components/Dashboard/QueuesView/TirednessView.tsx
@@ -21,7 +21,7 @@ export default class TirednessView extends React.Component<{
     );
   }
   renderBar(q: Tiredness) {
-    const upto = this.props.now.upto(q.scheduled);
+    const upto = this.props.now.upto(q.scheduled) + 1;
     const percentage = Math.floor(upto * 60 * 1000 * 100 / q.interval);
     return (
       <div className="column tiredness-bar-container">


### PR DESCRIPTION
fix #1095 